### PR TITLE
chore: Add tests for name and version config

### DIFF
--- a/instrumentation/logger/test/opentelemetry/instrumentation/logger/patches/logger_test.rb
+++ b/instrumentation/logger/test/opentelemetry/instrumentation/logger/patches/logger_test.rb
@@ -15,10 +15,11 @@ describe OpenTelemetry::Instrumentation::Logger::Patches::Logger do
   let(:log_stream) { StringIO.new }
   let(:ruby_logger) { Logger.new(log_stream) }
   let(:msg) { 'message' }
+  let(:config) { {} }
 
   before do
     exporter.reset
-    instrumentation.install
+    instrumentation.install(config)
   end
 
   after { instrumentation.instance_variable_set(:@installed, false) }
@@ -35,9 +36,44 @@ describe OpenTelemetry::Instrumentation::Logger::Patches::Logger do
       assert_equal(OpenTelemetry::Instrumentation::Logger::VERSION, log_record.instrumentation_scope.version)
     end
 
-    it 'sets the OTel logger instrumentation name and version (user defined)' do
-      ruby_logger.debug(msg)
-      skip 'TODO: write tests for configuration options'
+    describe 'configuration options' do
+      describe 'when a user configures name' do
+        let(:config) { { name: 'custom_logger' } }
+
+        it 'updates the logger name' do
+          ruby_logger.debug(msg)
+          assert_equal('custom_logger', log_record.instrumentation_scope.name)
+        end
+
+        it 'uses the default version' do
+          ruby_logger.debug(msg)
+          assert_equal(OpenTelemetry::Instrumentation::Logger::VERSION, log_record.instrumentation_scope.version)
+        end
+      end
+
+      describe 'when a user configures version' do
+        let(:config) { { version: '5000' } }
+
+        it 'updates the logger version' do
+          ruby_logger.debug(msg)
+          assert_equal('5000', log_record.instrumentation_scope.version)
+        end
+
+        it 'uses the default name' do
+          ruby_logger.debug(msg)
+          assert_equal(OpenTelemetry::Instrumentation::Logger::NAME, log_record.instrumentation_scope.name)
+        end
+      end
+
+      describe 'when a user configures both name and version' do
+        let(:config) { { name: 'custom_logger', version: '5000'} }
+
+        it 'updates both values' do
+          ruby_logger.debug(msg)
+          assert_equal('custom_logger', log_record.instrumentation_scope.name)
+          assert_equal('5000', log_record.instrumentation_scope.version)
+        end
+      end
     end
 
     it 'accepts custom logger provider ' do


### PR DESCRIPTION
While reviewing https://github.com/kaylareopelle/opentelemetry-ruby-contrib/pull/4, I decided to write some of the tests for the name and version config options. They're currently failing, but I think these are the scenarios we want to pass.